### PR TITLE
Do not let static gateways of inactive interfaces disappear.

### DIFF
--- a/vpnc-script-win.js
+++ b/vpnc-script-win.js
@@ -222,6 +222,16 @@ case "connect":
 	break;
 case "disconnect":
 	var gw = getDefaultGateway();
+	var address_array = env("INTERNAL_IP4_ADDRESS").split(".");
+	var netmask_array = env("INTERNAL_IP4_NETMASK").split(".");
+	// Calculate the first usable address in subnet
+	var internal_gw_array = new Array(
+		address_array[0] & netmask_array[0],
+		address_array[1] & netmask_array[1],
+		address_array[2] & netmask_array[2],
+		(address_array[3] & netmask_array[3]) + 1
+	);
+	var internal_gw = internal_gw_array.join(".");
 
 	echo("Default Gateway: " + gw)
 	echo("Interface idx: " + env("TUNIDX") + " (\"" + env("TUNDEV") + "\")");
@@ -232,7 +242,7 @@ case "disconnect":
 
 	// Restore direct route
 	echo("Restoring Direct Route");
-	exec("route delete 0.0.0.0 mask 0.0.0.0 ");
+	exec("route delete 0.0.0.0 mask 0.0.0.0 internal_gw");
 	exec("route add 0.0.0.0 mask 0.0.0.0 " + gw);
 
 	// ReSet Tunnel Adapter IP = nothing


### PR DESCRIPTION
**Describe the bug**
I have a static network connection on my docking station. When I leave this dock, I use WLAN. When I am in the WLAN, I use OpenConnect-GUI to connect to a network. Disconnecting OpenConnect-GUI then removes the gateway from the dock's inactive network connection.

**Steps to reproduce the behavior:**
1. Use a docking station's weired connection with a static IP address and a static gateway.
2. Leave the docking station.
3. Connect to a WLAN.
4. Establish an OpenConnect-GUI connection.
5. Disconnect OpenConnect-GUI.
6. Reattach the docking station.
7. The docking station's weired connection has lost its static gateway.

**Expected behavior**
The gateway does not get lost.

**Desktop (please complete the following information):**
 - OS: Windows 10