### PR TITLE
In disconnect routine: use variable's content, not its name.

### DIFF
--- a/vpnc-script-win.js
+++ b/vpnc-script-win.js
@@ -242,7 +242,7 @@ case "disconnect":
 
 	// Restore direct route
 	echo("Restoring Direct Route");
-	exec("route delete 0.0.0.0 mask 0.0.0.0 internal_gw");
+	exec("route delete 0.0.0.0 mask 0.0.0.0" + internal_gw);
 	exec("route add 0.0.0.0 mask 0.0.0.0 " + gw);
 
 	// ReSet Tunnel Adapter IP = nothing


### PR DESCRIPTION
In the `'disconnect'` restoring the direct route:

`internal_gw` is a variable and its content is supposed to be concatenated to the string instead of citing the name at the end of the literal string.